### PR TITLE
Add "KPackageStructure" prop. (Update metadata.json for KDE Plasma 6)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,5 +19,6 @@
         "Version": "1.0",
         "Website": "https://plasma.kde.org/"
     },
-    "X-KDE-ParentApp": "org.kde.plasmashell"
+    "X-KDE-ParentApp": "org.kde.plasmashell",
+    "KPackageStructure": "KSysguard/SensorFace"
 }


### PR DESCRIPTION
KDE Ksysguard wasn't showing the sensor face because of the newly required property "KPackageStructure"